### PR TITLE
Fixes attack issue in piecewise functions

### DIFF
--- a/examples/readme/Readme.purs
+++ b/examples/readme/Readme.purs
@@ -15,7 +15,7 @@ import Data.Typelevel.Num (D1, D2)
 import Data.Vec ((+>), empty)
 import Effect (Effect)
 import FRP.Behavior (Behavior)
-import FRP.Behavior.Audio (AV(..), AudioContext, AudioInfo, AudioParameterTransition(..), AudioUnit, CanvasInfo(..), EngineInfo, Exporter, IAudioUnit(..), VisualInfo, defaultExporter, dup1, g'add, g'bandpass, g'delay, g'gain, gain', gainT', graph, merger, microphone, panner, play, runInBrowser_, sinOsc, speaker, speaker')
+import FRP.Behavior.Audio (AV(..), AudioContext, AudioInfo, AudioUnit, CanvasInfo(..), EngineInfo, Exporter, IAudioUnit(..), VisualInfo, defaultExporter, defaultParam, dup1, g'add, g'bandpass, g'delay, g'gain, gain', gainT', graph, merger, microphone, panner, play, runInBrowser_, sinOsc, speaker, speaker')
 import FRP.Behavior.Mouse (buttons, position)
 import FRP.Event.Mouse (Mouse, getMouse)
 import Foreign.Object (Object)
@@ -140,14 +140,14 @@ scene6 mouse time = f time <$> click
       -- we lock to that
       -- otherwise, we interpolate
       if (fst right - s) < kr then
-        { param: (snd right), timeOffset: (fst right - s), transition: LinearRamp }
+        defaultParam { param = (snd right), timeOffset = (fst right - s) }
       else
         let
           m = (snd right - snd left) / (fst right - fst left)
 
           b = (snd right - (m * fst right))
         in
-          { param: (m * s + b), timeOffset: 0.0, transition: LinearRamp }
+          defaultParam { param = (m * s + b), timeOffset = 0.0 }
 
   f s cl =
     let
@@ -191,14 +191,14 @@ scene7 mouse acc@{ onset } time = f time <$> click
       -- we lock to that
       -- otherwise, we interpolate
       if (fst right - s) < kr then
-        { param: (snd right), timeOffset: (fst right - s), transition: LinearRamp }
+        defaultParam { param = (snd right), timeOffset = (fst right - s) }
       else
         let
           m = (snd right - snd left) / (fst right - fst left)
 
           b = (snd right - (m * fst right))
         in
-          { param: (m * s + b), timeOffset: 0.0, transition: LinearRamp }
+          defaultParam { param = (m * s + b), timeOffset = 0.0 }
 
   f s cl =
     IAudioUnit
@@ -247,14 +247,14 @@ scene7_1 mouse acc@{ onset } time = f time <$> click
       -- we lock to that
       -- otherwise, we interpolate
       if (fst right - s) < kr then
-        { param: (snd right), timeOffset: (fst right - s), transition: LinearRamp }
+        defaultParam { param = (snd right), timeOffset = (fst right - s) }
       else
         let
           m = (snd right - snd left) / (fst right - fst left)
 
           b = (snd right - (m * fst right))
         in
-          { param: (m * s + b), timeOffset: 0.0, transition: LinearRamp }
+          defaultParam { param = (m * s + b), timeOffset = 0.0 }
 
   f s cl =
     IAudioUnit
@@ -318,14 +318,14 @@ scene8 mouse acc@{ onset } (CanvasInfo { w, h, boundingClientRect: { x, y } }) t
       -- we lock to that
       -- otherwise, we interpolate
       if (fst right - s) < kr then
-        { param: (snd right), timeOffset: (fst right - s), transition: LinearRamp }
+        defaultParam { param = (snd right), timeOffset = (fst right - s) }
       else
         let
           m = (snd right - snd left) / (fst right - fst left)
 
           b = (snd right - (m * fst right))
         in
-          { param: (m * s + b), timeOffset: 0.0, transition: LinearRamp }
+          defaultParam { param = (m * s + b), timeOffset = 0.0 }
 
   f s cl ps =
     AV

--- a/test/Basic.purs
+++ b/test/Basic.purs
@@ -133,7 +133,7 @@ basicTestSuite = do
                         }
                     )
                   , ( Tuple 1
-                        { au: (Gain' $ { transition: LinearRamp, param: 0.5, timeOffset: 0.0 })
+                        { au: (Gain' $ { transition: LinearRamp, forceSet: false, param: 0.5, timeOffset: 0.0 })
                         , chan: 3
                         , head: 1
                         , name: Nothing
@@ -159,7 +159,7 @@ basicTestSuite = do
                         }
                     )
                   , ( Tuple 3
-                        { au: (Gain' $ { transition: LinearRamp, param: 0.3, timeOffset: 0.0 })
+                        { au: (Gain' $ { transition: LinearRamp, forceSet: false, param: 0.3, timeOffset: 0.0 })
                         , chan: 1
                         , head: 3
                         , name: Nothing
@@ -187,7 +187,7 @@ basicTestSuite = do
                         }
                     )
                   , ( Tuple 5
-                        { au: (Gain' $ { transition: LinearRamp, param: 0.3, timeOffset: 0.0 })
+                        { au: (Gain' $ { transition: LinearRamp, forceSet: false, param: 0.3, timeOffset: 0.0 })
                         , chan: 1
                         , head: 5
                         , name: Nothing
@@ -201,7 +201,7 @@ basicTestSuite = do
                         }
                     )
                   , (Tuple 6 { au: (SplitRes' 1), chan: 1, head: 6, name: Nothing, next: (fromFoldable (5 : Nil)), prev: (fromFoldable Nil), ptr: 6, status: On })
-                  , (Tuple 7 { au: (Gain' $ { transition: LinearRamp, param: 0.3, timeOffset: 0.0 }), chan: 1, head: 7, name: Nothing, next: (fromFoldable (2 : Nil)), prev: (fromFoldable (8 : Nil)), ptr: 7, status: On })
+                  , (Tuple 7 { au: (Gain' $ { transition: LinearRamp, forceSet: false, param: 0.3, timeOffset: 0.0 }), chan: 1, head: 7, name: Nothing, next: (fromFoldable (2 : Nil)), prev: (fromFoldable (8 : Nil)), ptr: 7, status: On })
                   , ( Tuple 8
                         { au: (SplitRes' 2)
                         , chan: 1
@@ -228,14 +228,15 @@ basicTestSuite = do
                     )
                   , (Tuple 10 { au: (Merger' (29 : 20 : 11 : Nil)), chan: 3, head: 10, name: Nothing, next: (fromFoldable (9 : Nil)), prev: (fromFoldable (11 : 20 : 29 : Nil)), ptr: 10, status: On })
                   , (Tuple 11 { au: Add', chan: 1, head: 11, name: Nothing, next: (fromFoldable (10 : Nil)), prev: (fromFoldable (12 : 16 : Nil)), ptr: 11, status: On })
-                  , (Tuple 12 { au: (Gain' $ { transition: LinearRamp, param: 1.0, timeOffset: 0.0 }), chan: 1, head: 12, name: Nothing, next: (fromFoldable (11 : Nil)), prev: (fromFoldable (13 : 14 : 15 : Nil)), ptr: 12, status: On })
-                  , (Tuple 13 { au: (SinOsc' $ { transition: LinearRamp, param: 440.0, timeOffset: 0.0 }), chan: 1, head: 13, name: Nothing, next: (fromFoldable (12 : Nil)), prev: (fromFoldable Nil), ptr: 13, status: On })
-                  , (Tuple 14 { au: (SinOsc' $ { transition: LinearRamp, param: 441.0, timeOffset: 0.0 }), chan: 1, head: 14, name: Nothing, next: (fromFoldable (12 : Nil)), prev: (fromFoldable Nil), ptr: 14, status: On })
-                  , (Tuple 15 { au: (SinOsc' $ { transition: LinearRamp, param: 441.0, timeOffset: 0.0 }), chan: 1, head: 15, name: Nothing, next: (fromFoldable (12 : Nil)), prev: (fromFoldable Nil), ptr: 15, status: On })
+                  , (Tuple 12 { au: (Gain' $ { transition: LinearRamp, forceSet: false, param: 1.0, timeOffset: 0.0 }), chan: 1, head: 12, name: Nothing, next: (fromFoldable (11 : Nil)), prev: (fromFoldable (13 : 14 : 15 : Nil)), ptr: 12, status: On })
+                  , (Tuple 13 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 440.0, timeOffset: 0.0 }), chan: 1, head: 13, name: Nothing, next: (fromFoldable (12 : Nil)), prev: (fromFoldable Nil), ptr: 13, status: On })
+                  , (Tuple 14 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 441.0, timeOffset: 0.0 }), chan: 1, head: 14, name: Nothing, next: (fromFoldable (12 : Nil)), prev: (fromFoldable Nil), ptr: 14, status: On })
+                  , (Tuple 15 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 441.0, timeOffset: 0.0 }), chan: 1, head: 15, name: Nothing, next: (fromFoldable (12 : Nil)), prev: (fromFoldable Nil), ptr: 15, status: On })
                   , ( Tuple 16
                         { au:
                             ( Gain'
                                 $ { param: 0.9
+                                  , forceSet: false
                                   , timeOffset: 0.0
                                   , transition: LinearRamp
                                   }
@@ -249,12 +250,12 @@ basicTestSuite = do
                         , status: On
                         }
                     )
-                  , (Tuple 17 { au: (SinOsc' $ { transition: LinearRamp, param: 442.0, timeOffset: 0.0 }), chan: 1, head: 17, name: Nothing, next: (fromFoldable (16 : Nil)), prev: (fromFoldable Nil), ptr: 17, status: On })
-                  , (Tuple 18 { au: (SinOsc' $ { transition: LinearRamp, param: 443.0, timeOffset: 0.0 }), chan: 1, head: 18, name: Nothing, next: (fromFoldable (16 : Nil)), prev: (fromFoldable Nil), ptr: 18, status: On })
-                  , (Tuple 19 { au: (SinOsc' $ { transition: LinearRamp, param: 443.0, timeOffset: 0.0 }), chan: 1, head: 19, name: Nothing, next: (fromFoldable (16 : Nil)), prev: (fromFoldable Nil), ptr: 19, status: On })
+                  , (Tuple 17 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 442.0, timeOffset: 0.0 }), chan: 1, head: 17, name: Nothing, next: (fromFoldable (16 : Nil)), prev: (fromFoldable Nil), ptr: 17, status: On })
+                  , (Tuple 18 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 443.0, timeOffset: 0.0 }), chan: 1, head: 18, name: Nothing, next: (fromFoldable (16 : Nil)), prev: (fromFoldable Nil), ptr: 18, status: On })
+                  , (Tuple 19 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 443.0, timeOffset: 0.0 }), chan: 1, head: 19, name: Nothing, next: (fromFoldable (16 : Nil)), prev: (fromFoldable Nil), ptr: 19, status: On })
                   , (Tuple 20 { au: Add', chan: 1, head: 20, name: Nothing, next: (fromFoldable (10 : Nil)), prev: (fromFoldable (21 : 25 : Nil)), ptr: 20, status: On })
                   , ( Tuple 21
-                        { au: (Gain' $ { transition: LinearRamp, param: 1.0, timeOffset: 0.0 })
+                        { au: (Gain' $ { transition: LinearRamp, forceSet: false, param: 1.0, timeOffset: 0.0 })
                         , chan: 1
                         , head: 21
                         , name: Nothing
@@ -264,13 +265,13 @@ basicTestSuite = do
                         , status: On
                         }
                     )
-                  , (Tuple 22 { au: (SinOsc' $ { transition: LinearRamp, param: 440.0, timeOffset: 0.0 }), chan: 1, head: 22, name: Nothing, next: (fromFoldable (21 : Nil)), prev: (fromFoldable Nil), ptr: 22, status: On })
-                  , (Tuple 23 { au: (SinOsc' $ { transition: LinearRamp, param: 441.0, timeOffset: 0.0 }), chan: 1, head: 23, name: Nothing, next: (fromFoldable (21 : Nil)), prev: (fromFoldable Nil), ptr: 23, status: On })
-                  , (Tuple 24 { au: (SinOsc' $ { transition: LinearRamp, param: 441.0, timeOffset: 0.0 }), chan: 1, head: 24, name: Nothing, next: (fromFoldable (21 : Nil)), prev: (fromFoldable Nil), ptr: 24, status: On })
-                  , (Tuple 25 { au: (Gain' $ { transition: LinearRamp, param: 0.9, timeOffset: 0.0 }), chan: 1, head: 25, name: Nothing, next: (fromFoldable (20 : Nil)), prev: (fromFoldable (26 : 27 : 28 : Nil)), ptr: 25, status: On })
-                  , (Tuple 26 { au: (SinOsc' $ { transition: LinearRamp, param: 442.0, timeOffset: 0.0 }), chan: 1, head: 26, name: Nothing, next: (fromFoldable (25 : Nil)), prev: (fromFoldable Nil), ptr: 26, status: On })
+                  , (Tuple 22 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 440.0, timeOffset: 0.0 }), chan: 1, head: 22, name: Nothing, next: (fromFoldable (21 : Nil)), prev: (fromFoldable Nil), ptr: 22, status: On })
+                  , (Tuple 23 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 441.0, timeOffset: 0.0 }), chan: 1, head: 23, name: Nothing, next: (fromFoldable (21 : Nil)), prev: (fromFoldable Nil), ptr: 23, status: On })
+                  , (Tuple 24 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 441.0, timeOffset: 0.0 }), chan: 1, head: 24, name: Nothing, next: (fromFoldable (21 : Nil)), prev: (fromFoldable Nil), ptr: 24, status: On })
+                  , (Tuple 25 { au: (Gain' $ { transition: LinearRamp, forceSet: false, param: 0.9, timeOffset: 0.0 }), chan: 1, head: 25, name: Nothing, next: (fromFoldable (20 : Nil)), prev: (fromFoldable (26 : 27 : 28 : Nil)), ptr: 25, status: On })
+                  , (Tuple 26 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 442.0, timeOffset: 0.0 }), chan: 1, head: 26, name: Nothing, next: (fromFoldable (25 : Nil)), prev: (fromFoldable Nil), ptr: 26, status: On })
                   , ( Tuple 27
-                        { au: (SinOsc' $ { transition: LinearRamp, param: 443.0, timeOffset: 0.0 })
+                        { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 443.0, timeOffset: 0.0 })
                         , chan: 1
                         , head: 27
                         , name: Nothing
@@ -283,11 +284,11 @@ basicTestSuite = do
                         , status: On
                         }
                     )
-                  , (Tuple 28 { au: (SinOsc' $ { transition: LinearRamp, param: 443.0, timeOffset: 0.0 }), chan: 1, head: 28, name: Nothing, next: (fromFoldable (25 : Nil)), prev: (fromFoldable Nil), ptr: 28, status: On })
+                  , (Tuple 28 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 443.0, timeOffset: 0.0 }), chan: 1, head: 28, name: Nothing, next: (fromFoldable (25 : Nil)), prev: (fromFoldable Nil), ptr: 28, status: On })
                   , (Tuple 29 { au: Add', chan: 1, head: 29, name: Nothing, next: (fromFoldable (10 : Nil)), prev: (fromFoldable (30 : 34 : Nil)), ptr: 29, status: On })
-                  , (Tuple 30 { au: (Gain' $ { transition: LinearRamp, param: 1.0, timeOffset: 0.0 }), chan: 1, head: 30, name: Nothing, next: (fromFoldable (29 : Nil)), prev: (fromFoldable (31 : 32 : 33 : Nil)), ptr: 30, status: On })
+                  , (Tuple 30 { au: (Gain' $ { transition: LinearRamp, forceSet: false, param: 1.0, timeOffset: 0.0 }), chan: 1, head: 30, name: Nothing, next: (fromFoldable (29 : Nil)), prev: (fromFoldable (31 : 32 : 33 : Nil)), ptr: 30, status: On })
                   , ( Tuple 31
-                        { au: (SinOsc' $ { transition: LinearRamp, param: 440.0, timeOffset: 0.0 })
+                        { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 440.0, timeOffset: 0.0 })
                         , chan: 1
                         , head: 31
                         , name: Nothing
@@ -297,12 +298,12 @@ basicTestSuite = do
                         , status: On
                         }
                     )
-                  , (Tuple 32 { au: (SinOsc' $ { transition: LinearRamp, param: 441.0, timeOffset: 0.0 }), chan: 1, head: 32, name: Nothing, next: (fromFoldable (30 : Nil)), prev: (fromFoldable Nil), ptr: 32, status: On })
-                  , (Tuple 33 { au: (SinOsc' $ { transition: LinearRamp, param: 441.0, timeOffset: 0.0 }), chan: 1, head: 33, name: Nothing, next: (fromFoldable (30 : Nil)), prev: (fromFoldable Nil), ptr: 33, status: On })
-                  , (Tuple 34 { au: (Gain' $ { transition: LinearRamp, param: 0.9, timeOffset: 0.0 }), chan: 1, head: 34, name: Nothing, next: (fromFoldable (29 : Nil)), prev: (fromFoldable (35 : 36 : 37 : Nil)), ptr: 34, status: On })
-                  , (Tuple 35 { au: (SinOsc' $ { transition: LinearRamp, param: 442.0, timeOffset: 0.0 }), chan: 1, head: 35, name: Nothing, next: (fromFoldable (34 : Nil)), prev: (fromFoldable Nil), ptr: 35, status: On })
+                  , (Tuple 32 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 441.0, timeOffset: 0.0 }), chan: 1, head: 32, name: Nothing, next: (fromFoldable (30 : Nil)), prev: (fromFoldable Nil), ptr: 32, status: On })
+                  , (Tuple 33 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 441.0, timeOffset: 0.0 }), chan: 1, head: 33, name: Nothing, next: (fromFoldable (30 : Nil)), prev: (fromFoldable Nil), ptr: 33, status: On })
+                  , (Tuple 34 { au: (Gain' $ { transition: LinearRamp, forceSet: false, param: 0.9, timeOffset: 0.0 }), chan: 1, head: 34, name: Nothing, next: (fromFoldable (29 : Nil)), prev: (fromFoldable (35 : 36 : 37 : Nil)), ptr: 34, status: On })
+                  , (Tuple 35 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 442.0, timeOffset: 0.0 }), chan: 1, head: 35, name: Nothing, next: (fromFoldable (34 : Nil)), prev: (fromFoldable Nil), ptr: 35, status: On })
                   , ( Tuple 36
-                        { au: (SinOsc' $ { transition: LinearRamp, param: 443.0, timeOffset: 0.0 })
+                        { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 443.0, timeOffset: 0.0 })
                         , chan: 1
                         , head: 36
                         , name: Nothing
@@ -312,7 +313,7 @@ basicTestSuite = do
                         , status: On
                         }
                     )
-                  , (Tuple 37 { au: (SinOsc' $ { transition: LinearRamp, param: 443.0, timeOffset: 0.0 }), chan: 1, head: 37, name: Nothing, next: (fromFoldable (34 : Nil)), prev: (fromFoldable Nil), ptr: 37, status: On })
+                  , (Tuple 37 { au: (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 443.0, timeOffset: 0.0 }), chan: 1, head: 37, name: Nothing, next: (fromFoldable (34 : Nil)), prev: (fromFoldable Nil), ptr: 37, status: On })
                   ]
               )
           , len: 38
@@ -358,7 +359,7 @@ basicTestSuite = do
                     )
                   , ( Tuple 2
                         { au:
-                            (SinOsc' $ { transition: LinearRamp, param: 42.0, timeOffset: 0.0 })
+                            (SinOsc' $ { transition: LinearRamp, forceSet: false, param: 42.0, timeOffset: 0.0 })
                         , head: 2
                         , chan: 1
                         , name: Nothing
@@ -491,10 +492,10 @@ basicTestSuite = do
                   , ( Tuple 1
                         { au:
                             ( Bandpass'
-                                ( { param: 440.0, timeOffset: 0.0, transition: LinearRamp
+                                ( { param: 440.0, forceSet: false, timeOffset: 0.0, transition: LinearRamp
                                   }
                                 )
-                                ({ transition: LinearRamp, param: 1.0, timeOffset: 0.0 })
+                                ({ transition: LinearRamp, forceSet: false, param: 1.0, timeOffset: 0.0 })
                             )
                         , chan: 1
                         , head: 1
@@ -531,6 +532,7 @@ basicTestSuite = do
                         { au:
                             ( SinOsc'
                                 ( { param: 440.0
+                                  , forceSet: false
                                   , timeOffset: 0.0
                                   , transition: LinearRamp
                                   }
@@ -586,7 +588,7 @@ basicTestSuite = do
                         }
                     )
                   , ( Tuple 1
-                        { au: (Bandpass' ({ transition: LinearRamp, param: 440.0, timeOffset: 0.0 }) ({ transition: LinearRamp, param: 1.0, timeOffset: 0.0 }))
+                        { au: (Bandpass' ({ transition: LinearRamp, forceSet: false, param: 440.0, timeOffset: 0.0 }) ({ transition: LinearRamp, forceSet: false, param: 1.0, timeOffset: 0.0 }))
                         , chan: 1
                         , head: 1
                         , name: Nothing
@@ -598,7 +600,7 @@ basicTestSuite = do
                         }
                     )
                   , ( Tuple 2
-                        { au: (Delay' ({ transition: LinearRamp, param: 0.2, timeOffset: 0.0 }))
+                        { au: (Delay' ({ transition: LinearRamp, forceSet: false, param: 0.2, timeOffset: 0.0 }))
                         , chan: 1
                         , head:
                             2


### PR DESCRIPTION
There was a bug where linear ramps were being set too early in piecewise functions, leading to audible clicks.
By forcing the kinks in piecewise functions to be rendered, we remove the clicks.